### PR TITLE
Kerberos with jwt support

### DIFF
--- a/src/clients/tlist/jwt_token.c
+++ b/src/clients/tlist/jwt_token.c
@@ -72,20 +72,27 @@
 #include <k5-json.h>
 #include <jwt_token.h>
 #include <k5-base64.h>
-
+#include <time.h>
 
 int
-jwt_token_create(jwt_token **out)
+jwt_token_create(jwt_token **out, char * token, int size)
 {
-    jwt_token *token;
+    jwt_token * local_token;
 
     *out = NULL;
 
-    token = (jwt_token*)calloc(1, sizeof(*token));
-    k5_json_object_create(&token->header);
-    k5_json_object_create(&token->body);
-
-    *out = token;
+    local_token = (jwt_token*)calloc(1, sizeof(*local_token));
+    
+    local_token->data = malloc(size + 1);
+    strncpy(local_token->data, token, size);
+    local_token->data[size] = 0;
+    local_token->head = NULL;
+    local_token->payload = NULL;
+    local_token->signature = NULL;
+    local_token->head_d = NULL;
+    local_token->payload_d = NULL;
+    
+    *out = local_token;
     return 0;
 }
 
@@ -108,29 +115,45 @@ char*
 jwt_token_header_attr(jwt_token *token, const char *name)
 {
     k5_json_value jvalue;
-
-    jvalue = k5_json_object_get(token->header, name);
-
-    return json_value_to_str(jvalue);
+    char * out;
+    k5_json_object * obj;
+    
+    k5_json_object_create(&obj);
+    k5_json_decode(token->head_d, &obj);
+    jvalue = k5_json_object_get(obj, name);
+    
+    out = json_value_to_str(jvalue);
+    k5_json_release(obj);
+    return out;
 }
 
 char*
 jwt_token_body_attr(jwt_token *token, const char *name)
 {
     k5_json_value jvalue;
-
-    jvalue = k5_json_object_get(token->body, name);
-
-    return json_value_to_str(jvalue);
+    char * out;
+    k5_json_object * obj = NULL;
+    
+    k5_json_object_create(&obj);
+    k5_json_decode(token->payload_d, &obj);
+    jvalue = k5_json_object_get(obj, name);
+    
+    out = json_value_to_str(jvalue);
+    k5_json_release(obj);
+    return out;
 }
 
 void
-jwt_token_destroy(jwt_token *token)
+jwt_token_destroy(jwt_token *local_token)
 {
-    if (! token) return;
-    k5_json_release(token->header);
-    k5_json_release(token->body);
-    free(token);
+    if (! local_token) return;
+    if (local_token->data) free(local_token->data);
+    if (local_token->head) free(local_token->head);
+    if (local_token->payload) free(local_token->payload);
+    if (local_token->signature) free(local_token->signature);
+    if (local_token->head_d) free(local_token->head_d);
+    if (local_token->payload_d) free(local_token->payload_d);
+    free(local_token);
 }
 
 static
@@ -168,80 +191,194 @@ base64url_decode(const char *str, size_t *len_out)
 }
 
 int
-jwt_token_decode(char *token, jwt_token **out)
+jwt_token_extract_int(const char *token, const char *sPattern) 
 {
-    char *p, *part1, *part2, *header, *header_t, *body, *body_t, *principal;
-    k5_json_value jvalue;
-    jwt_token *token_out;
-    size_t len_out = 0;
-    int retval = 0;
-    int x = 0;
+  const char * principal = token, * cPattern = sPattern;
+  int x = -3;
+  for(;*principal != 0;principal++) {
+    if(x == -3) {
+      if(*principal == *cPattern)
+        cPattern++;
+      else
+        cPattern = sPattern;
+      if(*cPattern == 0)
+        x = -2;
+    }
+    else if(x == -2) {
+      if(*principal == ' ' || *principal == '\t' || *principal == '\n')
+        continue;
+      if(*principal != ':') {
+        x = -3;
+        cPattern = sPattern;
+      }
+      else
+        x = -1;
+    }
+    else if(x == -1) {
+      if(*principal == ' ' || *principal == '\t' || *principal == '\n')
+        continue;
+      if(*principal < '0' || *principal > '9') {
+        x = -3;
+        cPattern = sPattern;
+      }
+      else
+        x = *principal - '0';
+    }
+    else if(*principal >= '0' && *principal <= '9') {
+      x = 10*x + (*principal) - '0';
+    }
+    else
+      break;
+  }
+  return x;
+}
 
-    *out = NULL;
-    p = strchr(token, '.');
+
+int
+jwt_token_structure_check(jwt_token * token)
+{
+    char * part1, * part2, * part3, * p, * local_token;
+    
+    if (token == NULL || token->data == NULL) {
+      return 1;
+    }
+    
+    local_token = (char *)malloc(strlen(token->data) + 1);
+    strncpy(local_token, token->data, strlen(token->data));
+    local_token[strlen(token->data)] = 0;
+    
+    part1 = local_token;
+    
+    p = strchr(local_token, '.');
     if (p == NULL) {
         return 1;
     }
     *p++ = 0;
+    
+    part2 = p;
+    p = strchr(p, '.');
     if (p == NULL) {
         return 1;
-    }    
-    part1 = token;
-    part2 = p;
-    p = strchr(part2, '.');
-    if (p != NULL) {
-        *p++ = 0;
     }
+    *p++ = 0;
     
-    header = (char*)base64url_decode((const char*)part1, &len_out);
-    header_t = (char *)malloc(len_out);
-    strncpy(header_t, header, len_out);
-    header_t[len_out] = '\0';
-    free(header);
-    body = (char*)base64url_decode((const char*)part2, &len_out);
-    body_t = (char *)malloc(len_out);
-    strncpy(body_t, body, len_out);
-    body_t[len_out] = '\0';
-    free(body);
-   
-    token_out = (jwt_token*)calloc(1, sizeof(*token_out));
-    k5_json_decode(header_t, &token_out->header);
-    k5_json_decode(body_t, &token_out->body);
-
-    free(header_t);
-    free(body_t);
-
-    principal = jwt_token_header_attr(token_out, "krbPrincipal");
-    if (principal == NULL) {
-    	principal = jwt_token_header_attr(token_out, "user_name");
-    	if (principal == NULL) {
-    	    principal = jwt_token_header_attr(token_out, "username");
-    	}
+    if (*p == 0) {
+      return 1;
     }
-    if (principal == NULL) {
-        principal = jwt_token_body_attr(token_out, "krbPrincipal");
-        if (principal == NULL) {
-    	    principal = jwt_token_body_attr(token_out, "user_name");
-    	    if (principal == NULL) {
-    	        principal = jwt_token_body_attr(token_out, "username");
-    	    }
-        }
-    }
-    if (principal == NULL) {
-        printf("Invalid token, unknown kr5 principal or user name\n");
-        return 1;
-    }
-
-    // replace @ to _
-    for(x=0; x<strlen(principal); x++) {
-      if(principal[x]=='@')
-        principal[x] = '_';
-    }
-
-    printf("krbPrincipal: %s\n", principal);
-
-    jwt_token_destroy(token_out);   
-
+    part3 = p;
+    
+    token->head = (char *)malloc(strlen(part1) + 1);
+    strncpy(token->head, part1, strlen(part1) + 1);
+    
+    token->payload = (char *)malloc(strlen(part2) + 1);
+    strncpy(token->payload, part2, strlen(part2) + 1);
+    
+    token->signature = (char *)malloc(strlen(part3) + 1);
+    strncpy(token->signature, part3, strlen(part3) + 1);
+    
+    free(local_token);
     return 0;
 }
 
+int
+jwt_token_decode(jwt_token * token) 
+{
+  size_t len_out = 0;
+  char * part1, * part2, * part1_d, * part2_d;
+  
+  if (token == NULL || token->head == NULL || token->payload == NULL) {
+    return 1;
+  }
+  
+  part1 = (char *)base64url_decode(token->head, &len_out);
+  if (part1 == NULL) {
+    return 1;
+  }
+  
+  part2 = (char *)base64url_decode(token->payload, &len_out);
+  if (part2 == NULL) {
+    return 1;
+  }
+  
+  token->head_d = part1;
+  token->payload_d = part2;
+  
+  return 0;
+}
+
+char * jwt_token_get_name(jwt_token * token) 
+{
+  char * principal;
+  int x;
+  
+  if (token == NULL || token->head_d == NULL || token->payload_d == NULL) {
+    return NULL;
+  }
+  
+  principal = jwt_token_header_attr(token, "krbPrincipal");
+  if (principal == NULL) {
+    principal = jwt_token_header_attr(token, "user_name");
+    if (principal == NULL) {
+      principal = jwt_token_header_attr(token, "username");
+    }
+  }
+  
+  if (principal == NULL) {
+    principal = jwt_token_body_attr(token, "krbPrincipal");
+    if (principal == NULL) {
+      principal = jwt_token_body_attr(token, "user_name");
+      if (principal == NULL) {
+        principal = jwt_token_body_attr(token, "username");
+      }
+    }
+  }
+  
+  if (principal == NULL) {
+    return NULL;
+  }
+  
+  // Replace @ to _ in principal name from token
+  for(x=0; x<strlen(principal); x++) {
+    if(principal[x]=='@')
+      principal[x] = '_';
+  }
+  
+  return principal;
+}
+
+int jwt_token_validate_principal_name(jwt_token * token, const char * user_name) 
+{
+  char * principal;
+  int x;
+  
+  principal = jwt_token_get_name(token);
+  
+  if (principal == NULL) {
+    return 2;
+  }
+  
+  if(strlen(principal) != strlen(user_name))
+    return 1;
+  else{
+    for(x=0;x<strlen(principal);x++){
+      if(principal[x]!=user_name[x]){
+        return 1;
+      }
+    }
+  }
+  
+  return 0;
+}
+
+int jwt_token_lifetime(jwt_token * token, krb5_timestamp * endtime) 
+{
+  int x = jwt_token_extract_int(token->payload_d, "\"exp\"");
+  
+  if(x<=(int)time(NULL)) {
+    return 1;
+  }
+  
+  *endtime = x;
+  
+  return 0;
+}

--- a/src/clients/tlist/ktinit
+++ b/src/clients/tlist/ktinit
@@ -2,56 +2,21 @@
 
 function usage() {
     echo "This tool uses token to authenticate to KDC and obtains tgt for you. "
-    echo "ktinit [-t token | -T token-cache-file] [-c kerb-ccache-file]"
+    echo "ktinit [-t token | -T token-cache-file] [-c kerb-ccache-file] [-P principal] [-W kinit and tlist directory]"
     echo "      when no token specified, ~/.tokenauth.token will be used by default"
     exit 1
-}
-
-function tinit() {
-    token="$1"
-    result_cc="$2"
-
-    tempOutput=`tlist $token`
-    if [ $? -ne 0 ]; then
-        echo "Failed to decode the token"
-        echo $tempOutput
-        exit 1
-    fi
-    principal=`echo $tempOutput | awk -F: '{print $2}'`
-    if [ X"$principal" = X ]; then
-        echo "Invalid token!"
-        exit 1
-    fi
-    echo "Will kinit with token for $principal"
-
-    armor_cc=/tmp/krb5cc_armor.$$
-    kinit -c $armor_cc -n
-    if [ $? != 0 ]; then
-        echo "Failed to obtain armor ticket"
-        exit 1
-    fi
-    
-    cc_opt=""
-    if [ X"$result_cc" != X ]; then
-	cc_opt="-c $result_cc"
-    fi
-
-    kinit -T $armor_cc $cc_opt -X token=$token $principal
-    if [ $? -ne 0 ]; then
-        echo "Failed to obtain tgt ticket with token"
-        rm -rf $armor_cc
-        exit 1
-    fi
-    
-    echo "Successfully obtained tgt in $result_cc cache file with token"
-    rm -rf $armor_cc
 }
 
 # Main
 
 token=""
 token_cache=""
+principal=""
+directory=""
 #result_cc="/tmp/krb5cc_tinit.$$"
+
+kinit="kinit"
+tlist="tlist"
 
 while [[ $# > 0 ]]; do
     key="$1"
@@ -66,10 +31,18 @@ while [[ $# > 0 ]]; do
 	    token_cache="$1"
 	    shift
 	    ;;
+        -P)
+            principal="$1"
+            shift
+            ;;
 	-c)
 	    result_cc="$1"
 	    shift
 	    ;;
+        -W)
+            directory="$1"
+            shift
+            ;;
 	-h)
 	    usage
 	    ;;
@@ -78,6 +51,11 @@ while [[ $# > 0 ]]; do
 	    ;;
     esac
 done
+
+if [[ X"$directory" != X ]]; then
+  kinit="$directory/kinit"
+  tlist="$directory/tlist"
+fi
 
 if [[ X"$token" != X &&  X"$token_cache" != X ]]; then
     echo "Either token or token-cache can be specified, not both"
@@ -93,10 +71,48 @@ if [ X"$token" = X ]; then
 	token=`cat ~/.tokenauth.token`
     fi
 fi
+
 if [ X"$token" = X ]; then
     echo "No token is available by default. Please specify your token either via -t or -T"
     usage
 fi
 
-tinit $token $result_cc
+if [ X"$principal" = X ]; then
+    tempOutput=`$tlist $token`
+    if [ $? -ne 0 ]; then
+        echo "Failed to decode the token"
+        echo $tempOutput
+        exit 1
+    fi
+    principal=`echo $tempOutput | awk -F: '{print $2}'`
+    if [ X"$principal" = X ]; then
+        echo "Invalid token!"
+        exit 1
+    fi
+fi
+
+echo "Will kinit with token for $principal"
+
+armor_cc=/tmp/krb5cc_armor.$$
+$kinit -c $armor_cc -n
+if [ $? != 0 ]; then
+    echo "Failed to obtain armor ticket"
+    exit 1
+fi
+
+cc_opt=""
+if [ X"$result_cc" != X ]; then
+    cc_opt="-c $result_cc"
+fi
+
+$kinit -T $armor_cc $cc_opt -X token=$token $principal
+if [ $? -ne 0 ]; then
+    echo "Failed to obtain tgt ticket with token"
+    rm -rf $armor_cc
+    exit 1
+fi
+
+echo "Successfully obtained tgt in $result_cc cache file with token"
+rm -rf $armor_cc
+
 exit 0

--- a/src/clients/tlist/ktinit
+++ b/src/clients/tlist/ktinit
@@ -1,4 +1,27 @@
 #!/bin/bash
+#
+# Copyright 1990 by the Massachusetts Institute of Technology.
+# All Rights Reserved.
+#
+# Export of this software from the United States of America may
+#   require a specific license from the United States Government.
+#   It is the responsibility of any person or organization contemplating
+#   export to obtain such a license before exporting.
+#
+# WITHIN THAT CONSTRAINT, permission to use, copy, modify, and
+# distribute this software and its documentation for any purpose and
+# without fee is hereby granted, provided that the above copyright
+# notice appear in all copies and that both that copyright notice and
+# this permission notice appear in supporting documentation, and that
+# the name of M.I.T. not be used in advertising or publicity pertaining
+# to distribution of the software without specific, written prior
+# permission.  Furthermore if you modify this software you must label
+# your software as modified software and not distribute it in such a
+# fashion that it might be confused with the original M.I.T. software.
+# M.I.T. makes no representations about the suitability of
+# this software for any purpose.  It is provided "as is" without express
+# or implied warranty.
+#
 
 function usage() {
     echo "This tool uses token to authenticate to KDC and obtains tgt for you. "

--- a/src/clients/tlist/tlist.c
+++ b/src/clients/tlist/tlist.c
@@ -66,26 +66,57 @@ static void usage()
     exit(1);
 }
 
+int jwt_token_validate(jwt_token * token) {
+  int retval = 0;
+
+  retval = jwt_token_structure_check(token);
+  if (retval != 0) {
+    goto clean;
+  }
+  
+  retval = jwt_token_decode(token);
+  if (retval != 0) {
+    goto clean;
+  }
+
+clean:
+  return retval;
+}
 
 int
 main(argc, argv)
     int argc;
     char **argv;
 {
-    char *token = NULL;
-    jwt_token *out_token;
+    char *value = NULL;
+    jwt_token *token;
     int ret;
 
     setlocale(LC_ALL, "");
     progname = GET_PROGNAME(argv[0]);
 
     if (argc > 1) {
-        token = argv[1];
+        value = argv[1];
     } else {
         usage();
     }
 
-    ret = jwt_token_decode(token, &out_token);
+    if (jwt_token_create(&token, value, strlen(value)) != 0) {
+      return 1;
+    }
+    ret = jwt_token_validate(token);
+    
+    if (ret == 0) {
+      value = jwt_token_get_name(token);
+    
+      if (value == NULL) {
+        printf("Principal error\n");
+        ret = 1;
+      }
+      else {
+        printf("krbPrincipal: %s\n", value);
+      }
+    }
     
     return ret;
 }

--- a/src/include/jwt_token.h
+++ b/src/include/jwt_token.h
@@ -44,7 +44,7 @@ void jwt_token_destroy(jwt_token *token);
 
 int jwt_token_decode(char *token_str, jwt_token **out);
 
-int jwt_token_decode_and_check(char *token, const char * user_name, krb5_timestamp *endtime);
+int jwt_token_decode_and_check(char *token, const char * user_name, krb5_timestamp *endtime, void * rsa_pub);
 
 char* jwt_token_header_attr(jwt_token *token, const char *name);
 

--- a/src/include/jwt_token.h
+++ b/src/include/jwt_token.h
@@ -32,19 +32,27 @@
 #include <k5-int.h>
 #include <com_err.h>
 
-struct jwt_token_st {
-    k5_json_object header;
-    k5_json_object body;
-};
-typedef struct jwt_token_st jwt_token;
+#include <openssl/bio.h>
+#include <openssl/pem.h>
+#include <openssl/rsa.h>
+#include <openssl/sha.h>
 
-int jwt_token_create(jwt_token **out);
+typedef struct jwt_token_st {
+    char * data;
+    char * head, * payload, * signature;
+    char * head_d, * payload_d;
+} jwt_token;
+
+int jwt_token_create(jwt_token **out, char * token, int size);
 
 void jwt_token_destroy(jwt_token *token);
 
-int jwt_token_decode(char *token_str, jwt_token **out);
-
-int jwt_token_decode_and_check(char *token, const char * user_name, krb5_timestamp *endtime, void * rsa_pub);
+int jwt_token_structure_check(jwt_token * token);
+int jwt_token_decode(jwt_token * token);
+int jwt_token_validate_principal_name(jwt_token * token, const char * user_name);
+int jwt_token_lifetime(jwt_token * token, krb5_timestamp * endtime);
+int jwt_token_verify_signature(jwt_token * token, const RSA * rsa_public);
+char * jwt_token_get_name(jwt_token * token);
 
 char* jwt_token_header_attr(jwt_token *token, const char *name);
 

--- a/src/include/jwt_token.h
+++ b/src/include/jwt_token.h
@@ -44,6 +44,8 @@ void jwt_token_destroy(jwt_token *token);
 
 int jwt_token_decode(char *token_str, jwt_token **out);
 
+int jwt_token_decode_and_check(char *token, const char * user_name);
+
 char* jwt_token_header_attr(jwt_token *token, const char *name);
 
 char* jwt_token_body_attr(jwt_token *token, const char *name);

--- a/src/include/jwt_token.h
+++ b/src/include/jwt_token.h
@@ -44,7 +44,7 @@ void jwt_token_destroy(jwt_token *token);
 
 int jwt_token_decode(char *token_str, jwt_token **out);
 
-int jwt_token_decode_and_check(char *token, const char * user_name);
+int jwt_token_decode_and_check(char *token, const char * user_name, krb5_timestamp *endtime);
 
 char* jwt_token_header_attr(jwt_token *token, const char *name);
 

--- a/src/lib/jwttoken/jwt_token.c
+++ b/src/lib/jwttoken/jwt_token.c
@@ -72,20 +72,27 @@
 #include <k5-json.h>
 #include <jwt_token.h>
 #include <k5-base64.h>
-
+#include <time.h>
 
 int
-jwt_token_create(jwt_token **out)
+jwt_token_create(jwt_token **out, char * token, int size)
 {
-    jwt_token *token;
+    jwt_token * local_token;
 
     *out = NULL;
 
-    token = (jwt_token*)calloc(1, sizeof(*token));
-    k5_json_object_create(&token->header);
-    k5_json_object_create(&token->body);
-
-    *out = token;
+    local_token = (jwt_token*)calloc(1, sizeof(*local_token));
+    
+    local_token->data = malloc(size + 1);
+    strncpy(local_token->data, token, size);
+    local_token->data[size] = 0;
+    local_token->head = NULL;
+    local_token->payload = NULL;
+    local_token->signature = NULL;
+    local_token->head_d = NULL;
+    local_token->payload_d = NULL;
+    
+    *out = local_token;
     return 0;
 }
 
@@ -108,29 +115,45 @@ char*
 jwt_token_header_attr(jwt_token *token, const char *name)
 {
     k5_json_value jvalue;
-
-    jvalue = k5_json_object_get(token->header, name);
-
-    return json_value_to_str(jvalue);
+    char * out;
+    k5_json_object * obj;
+    
+    k5_json_object_create(&obj);
+    k5_json_decode(token->head_d, &obj);
+    jvalue = k5_json_object_get(obj, name);
+    
+    out = json_value_to_str(jvalue);
+    k5_json_release(obj);
+    return out;
 }
 
 char*
 jwt_token_body_attr(jwt_token *token, const char *name)
 {
     k5_json_value jvalue;
-
-    jvalue = k5_json_object_get(token->body, name);
-
-    return json_value_to_str(jvalue);
+    char * out;
+    k5_json_object * obj = NULL;
+    
+    k5_json_object_create(&obj);
+    k5_json_decode(token->payload_d, &obj);
+    jvalue = k5_json_object_get(obj, name);
+    
+    out = json_value_to_str(jvalue);
+    k5_json_release(obj);
+    return out;
 }
 
 void
-jwt_token_destroy(jwt_token *token)
+jwt_token_destroy(jwt_token *local_token)
 {
-    if (! token) return;
-    k5_json_release(token->header);
-    k5_json_release(token->body);
-    free(token);
+    if (! local_token) return;
+    if (local_token->data) free(local_token->data);
+    if (local_token->head) free(local_token->head);
+    if (local_token->payload) free(local_token->payload);
+    if (local_token->signature) free(local_token->signature);
+    if (local_token->head_d) free(local_token->head_d);
+    if (local_token->payload_d) free(local_token->payload_d);
+    free(local_token);
 }
 
 static
@@ -139,6 +162,7 @@ base64url_decode(const char *str, size_t *len_out)
 {
     char *tmp;
     size_t len, padding_len, i;
+    void * ret;
 
     *len_out = SIZE_MAX;
 
@@ -151,7 +175,7 @@ base64url_decode(const char *str, size_t *len_out)
     for (i = 0; i < padding_len; ++i) {
         tmp[len +i] = '=';
     }
-
+    tmp[len + padding_len] = '\0';
     // Replace URL-safe chars
     for (i = 0; i < len; i++) {
         if (tmp[i] == '_') {
@@ -161,67 +185,200 @@ base64url_decode(const char *str, size_t *len_out)
         }
     }
 
-    return k5_base64_decode(tmp, len_out);
+    ret = k5_base64_decode(tmp, len_out);
+    free(tmp);
+    return ret;
 }
 
 int
-jwt_token_decode(char *token, jwt_token **out)
+jwt_token_extract_int(const char *token, const char *sPattern) 
 {
-    char *p, *part1, *part2, *header, *body, *principal;
-    k5_json_value jvalue;
-    jwt_token *token_out;
-    size_t len_out = 0;
+  const char * principal = token, * cPattern = sPattern;
+  int x = -3;
+  for(;*principal != 0;principal++) {
+    if(x == -3) {
+      if(*principal == *cPattern)
+        cPattern++;
+      else
+        cPattern = sPattern;
+      if(*cPattern == 0)
+        x = -2;
+    }
+    else if(x == -2) {
+      if(*principal == ' ' || *principal == '\t' || *principal == '\n')
+        continue;
+      if(*principal != ':') {
+        x = -3;
+        cPattern = sPattern;
+      }
+      else
+        x = -1;
+    }
+    else if(x == -1) {
+      if(*principal == ' ' || *principal == '\t' || *principal == '\n')
+        continue;
+      if(*principal < '0' || *principal > '9') {
+        x = -3;
+        cPattern = sPattern;
+      }
+      else
+        x = *principal - '0';
+    }
+    else if(*principal >= '0' && *principal <= '9') {
+      x = 10*x + (*principal) - '0';
+    }
+    else
+      break;
+  }
+  return x;
+}
 
-    *out = NULL;
 
-    p = strchr(token, '.');
+int
+jwt_token_structure_check(jwt_token * token)
+{
+    char * part1, * part2, * part3, * p, * local_token;
+    
+    if (token == NULL || token->data == NULL) {
+      return 1;
+    }
+    
+    local_token = (char *)malloc(strlen(token->data) + 1);
+    strncpy(local_token, token->data, strlen(token->data));
+    local_token[strlen(token->data)] = 0;
+    
+    part1 = local_token;
+    
+    p = strchr(local_token, '.');
     if (p == NULL) {
         return 1;
     }
     *p++ = 0;
+    
+    part2 = p;
+    p = strchr(p, '.');
     if (p == NULL) {
         return 1;
-    }    
-    part1 = token;
-    part2 = p;
-    p = strchr(part2, '.');
-    if (p != NULL) {
-        *p++ = 0;
     }
-
-    header = (char*)base64url_decode((const char*)part1, &len_out);
-    body = (char*)base64url_decode((const char*)part2, &len_out);
-
-    token_out = (jwt_token*)calloc(1, sizeof(*token_out));
-    k5_json_decode(header, &token_out->header);
-    k5_json_decode(body, &token_out->body);
-    *out = token_out;
-
-    principal = jwt_token_header_attr(token_out, "krbPrincipal");
-    if (principal == NULL) {
-    	principal = jwt_token_header_attr(token_out, "user_name");
-    	if (principal == NULL) {
-    	    principal = jwt_token_header_attr(token_out, "username");
-    	}
+    *p++ = 0;
+    
+    if (*p == 0) {
+      return 1;
     }
-
-    if (principal == NULL) {
-        principal = jwt_token_body_attr(token_out, "krbPrincipal");
-        if (principal == NULL) {
-    	    principal = jwt_token_body_attr(token_out, "user_name");
-    	    if (principal == NULL) {
-    	        principal = jwt_token_body_attr(token_out, "username");
-    	    }
-        }
-    }
-
-    if (principal == NULL) {
-        printf("Invalid token, unknown kr5 principal or user name\n");
-        return 1;
-    }
-
-    printf("krbPrincipal: %s\n", principal);
-
+    part3 = p;
+    
+    token->head = (char *)malloc(strlen(part1) + 1);
+    strncpy(token->head, part1, strlen(part1) + 1);
+    
+    token->payload = (char *)malloc(strlen(part2) + 1);
+    strncpy(token->payload, part2, strlen(part2) + 1);
+    
+    token->signature = (char *)malloc(strlen(part3) + 1);
+    strncpy(token->signature, part3, strlen(part3) + 1);
+    
+    free(local_token);
     return 0;
 }
 
+int
+jwt_token_decode(jwt_token * token) 
+{
+  size_t len_out = 0;
+  char * part1, * part2, * part1_d, * part2_d;
+  
+  if (token == NULL || token->head == NULL || token->payload == NULL) {
+    return 1;
+  }
+  
+  part1 = (char *)base64url_decode(token->head, &len_out);
+  if (part1 == NULL) {
+    return 1;
+  }
+  
+  part2 = (char *)base64url_decode(token->payload, &len_out);
+  if (part2 == NULL) {
+    return 1;
+  }
+  
+  token->head_d = part1;
+  token->payload_d = part2;
+  
+  return 0;
+}
+
+char * jwt_token_get_name(jwt_token * token) 
+{
+  char * principal;
+  int x;
+  
+  if (token == NULL || token->head_d == NULL || token->payload_d == NULL) {
+    return NULL;
+  }
+  
+  principal = jwt_token_header_attr(token, "krbPrincipal");
+  if (principal == NULL) {
+    principal = jwt_token_header_attr(token, "user_name");
+    if (principal == NULL) {
+      principal = jwt_token_header_attr(token, "username");
+    }
+  }
+  
+  if (principal == NULL) {
+    principal = jwt_token_body_attr(token, "krbPrincipal");
+    if (principal == NULL) {
+      principal = jwt_token_body_attr(token, "user_name");
+      if (principal == NULL) {
+        principal = jwt_token_body_attr(token, "username");
+      }
+    }
+  }
+  
+  if (principal == NULL) {
+    return NULL;
+  }
+  
+  // Replace @ to _ in principal name from token
+  for(x=0; x<strlen(principal); x++) {
+    if(principal[x]=='@')
+      principal[x] = '_';
+  }
+  
+  return principal;
+}
+
+int jwt_token_validate_principal_name(jwt_token * token, const char * user_name) 
+{
+  char * principal;
+  int x;
+  
+  principal = jwt_token_get_name(token);
+  
+  if (principal == NULL) {
+    return 2;
+  }
+  
+  if(strlen(principal) != strlen(user_name))
+    return 1;
+  else{
+    for(x=0;x<strlen(principal);x++){
+      if(principal[x]!=user_name[x]){
+        return 1;
+      }
+    }
+  }
+  
+  return 0;
+}
+
+int jwt_token_lifetime(jwt_token * token, krb5_timestamp * endtime) 
+{
+  int x = jwt_token_extract_int(token->payload_d, "\"exp\"");
+  
+  if(x<=(int)time(NULL)) {
+    return 1;
+  }
+  
+  *endtime = x;
+  
+  return 0;
+}

--- a/src/plugins/preauth/jwt/Makefile.in
+++ b/src/plugins/preauth/jwt/Makefile.in
@@ -9,8 +9,7 @@ RELDIR=../plugins/preauth/jwt
 # Depends on libk5crypto and libkrb5
 SHLIB_EXPDEPS = $(KRB5_BASE_DEPLIBS) $(SUPPORT_LIB)
 
-
-SHLIB_EXPLIBS= $(KRB5_BASE_LIBS)
+SHLIB_EXPLIBS= $(KRB5_BASE_LIBS) -lcrypto
 
 STLIBOBJS= \
 	jwt_srv.o \

--- a/src/plugins/preauth/jwt/jwt.h
+++ b/src/plugins/preauth/jwt/jwt.h
@@ -35,11 +35,6 @@
 #include <com_err.h>
 #include <jwt_token.h>
 
-#include <openssl/bio.h>
-#include <openssl/pem.h>
-#include <openssl/rsa.h>
-#include <openssl/sha.h>
-
 #define KRB5_JWT_PUBKEY_DIR "jwt_public_key"
 #define KRB5_JWT_CERT_MISSING_IGNORE "jwt_ignore_cert_missing"
 

--- a/src/plugins/preauth/jwt/jwt.h
+++ b/src/plugins/preauth/jwt/jwt.h
@@ -35,6 +35,18 @@
 #include <com_err.h>
 #include <jwt_token.h>
 
+#include <openssl/bio.h>
+#include <openssl/pem.h>
+#include <openssl/rsa.h>
+#include <openssl/sha.h>
+
+#define KRB5_JWT_PUBKEY_DIR "jwt_public_key"
+#define KRB5_JWT_CERT_MISSING_IGNORE "jwt_ignore_cert_missing"
+
+#define KRB5_CERT_MISSING_CODE 60
+#define KRB5_CERT_PARSE_FAILED 61
+#define KRB5_CERT_TOO_BIG 62
+
 /*
  * Client's plugin context
  */
@@ -73,6 +85,5 @@ struct _jwt_kdc_req_context {
     char *token;
 };
 typedef struct _jwt_kdc_req_context jwt_kdc_req_context;
-
 
 #endif /* JWT_H_ */

--- a/src/plugins/preauth/jwt/jwt_clnt.c
+++ b/src/plugins/preauth/jwt/jwt_clnt.c
@@ -107,7 +107,7 @@ make_request(krb5_context ctx, jwt_context *jwtctx, krb5_pa_jwt_req **out_req)
         goto error;
     
     req->token.data = strdup(jwtctx->token);
-    req->token.length = strlen(jwtctx->token);
+    req->token.length = strlen(jwtctx->token) + 1;
 
     *out_req = req;
     return 0;
@@ -250,12 +250,13 @@ handle_gic_opt(krb5_context context,
     	token = strdup(value);
         ret = jwt_token_decode(token, &out_token);
     	if (ret == 0) {
-            jwtctx->token = token;
+            jwtctx->token = strdup(value);
             jwtctx->vendor = strdup("jwt");
     	} else {
             jwtctx->token = NULL;
             jwtctx->vendor = NULL;
     	}
+        free(token);
     }
 
     return ret;

--- a/src/plugins/preauth/jwt/jwt_clnt.c
+++ b/src/plugins/preauth/jwt/jwt_clnt.c
@@ -236,19 +236,40 @@ jwt_client_request_fini(krb5_context context, krb5_clpreauth_moddata moddata,
     free(modreq);
 }
 
+int jwt_token_validate(jwt_token * token) {
+  int retval = 0;
+
+  retval = jwt_token_structure_check(token);
+  if (retval != 0) {
+    goto clean;
+  }
+  
+  retval = jwt_token_decode(token);
+  if (retval != 0) {
+    goto clean;
+  }
+
+clean:
+  return retval;
+}
+
 static krb5_error_code
 handle_gic_opt(krb5_context context,
                jwt_context *jwtctx,
                const char *attr,
                const char *value)
 {
-    char *token = NULL;
-    jwt_token *out_token;
+    jwt_token * token;
     int ret = 0;
-
     if (strcmp(attr, "token") == 0) {
-    	token = strdup(value);
-        ret = jwt_token_decode(token, &out_token);
+      if (jwt_token_create(&token, value, strlen(value)) != 0) {
+        jwtctx->token = NULL;
+        jwtctx->vendor = NULL;
+        ret = 1;
+        goto clean;
+      }
+      ret = jwt_token_validate(token);
+      jwt_token_destroy(token);
     	if (ret == 0) {
             jwtctx->token = strdup(value);
             jwtctx->vendor = strdup("jwt");
@@ -256,9 +277,8 @@ handle_gic_opt(krb5_context context,
             jwtctx->token = NULL;
             jwtctx->vendor = NULL;
     	}
-        free(token);
     }
-
+clean:
     return ret;
 }
 

--- a/src/plugins/preauth/jwt/jwt_srv.c
+++ b/src/plugins/preauth/jwt/jwt_srv.c
@@ -75,14 +75,15 @@ token_verify(krb5_context ctx, krb5_keyblock *armor_key,
         retval = EINVAL;
     }
 
-    retval = jwt_token_decode(token, &out_token);
-	if (retval != 0) {
-		retval = EINVAL;
-	}
+    // It is bugged
+    retval = jwt_token_decode(token->data, &out_token);
+    if (retval != 0) {
+      retval = EINVAL;
+    }
 
-	// todo: very the token according to the spec
+    // todo: very the token according to the spec
 
-	return retval;
+    return retval;
 }
 
 static krb5_error_code

--- a/src/plugins/preauth/jwt/jwt_token.c
+++ b/src/plugins/preauth/jwt/jwt_token.c
@@ -306,9 +306,11 @@ jwt_token_decode_and_check(char *token, const char * user_name)
     }
     if (principal == NULL) {
         printf("Invalid token, unknown kr5 principal or user name\n");
-        return 1;
+        retval = 1;
+        com_err("jwt_err", 0, "Cannot find principal username");
+        goto clean;
     }
-
+    
     // replace @ to _
     for(x=0; x<strlen(principal); x++) {
       if(principal[x]=='@')
@@ -321,11 +323,13 @@ jwt_token_decode_and_check(char *token, const char * user_name)
       for(x=0;x<strlen(principal);x++){
         if(principal[x]!=user_name[x]){
           retval = 1;
-          break;
+          com_err("jwt_compare", 0, "Compare names failed");
+          goto clean;
         }
       }
     }
 
+clean:
     jwt_token_destroy(token_out);
 
     return retval;

--- a/src/plugins/preauth/jwt/jwt_token.c
+++ b/src/plugins/preauth/jwt/jwt_token.c
@@ -76,17 +76,24 @@
 #include "jwt.h"
 
 int
-jwt_token_create(jwt_token **out)
+jwt_token_create(jwt_token **out, char * token, int size)
 {
-    jwt_token *token;
+    jwt_token * local_token;
 
     *out = NULL;
 
-    token = (jwt_token*)calloc(1, sizeof(*token));
-    k5_json_object_create(&token->header);
-    k5_json_object_create(&token->body);
-
-    *out = token;
+    local_token = (jwt_token*)calloc(1, sizeof(*local_token));
+    
+    local_token->data = malloc(size + 1);
+    strncpy(local_token->data, token, size);
+    local_token->data[size] = 0;
+    local_token->head = NULL;
+    local_token->payload = NULL;
+    local_token->signature = NULL;
+    local_token->head_d = NULL;
+    local_token->payload_d = NULL;
+    
+    *out = local_token;
     return 0;
 }
 
@@ -109,29 +116,45 @@ char*
 jwt_token_header_attr(jwt_token *token, const char *name)
 {
     k5_json_value jvalue;
-
-    jvalue = k5_json_object_get(token->header, name);
-
-    return json_value_to_str(jvalue);
+    char * out;
+    k5_json_object * obj;
+    
+    k5_json_object_create(&obj);
+    k5_json_decode(token->head_d, &obj);
+    jvalue = k5_json_object_get(obj, name);
+    
+    out = json_value_to_str(jvalue);
+    k5_json_release(obj);
+    return out;
 }
 
 char*
 jwt_token_body_attr(jwt_token *token, const char *name)
 {
     k5_json_value jvalue;
-
-    jvalue = k5_json_object_get(token->body, name);
-
-    return json_value_to_str(jvalue);
+    char * out;
+    k5_json_object * obj = NULL;
+    
+    k5_json_object_create(&obj);
+    k5_json_decode(token->payload_d, &obj);
+    jvalue = k5_json_object_get(obj, name);
+    
+    out = json_value_to_str(jvalue);
+    k5_json_release(obj);
+    return out;
 }
 
 void
-jwt_token_destroy(jwt_token *token)
+jwt_token_destroy(jwt_token *local_token)
 {
-    if (! token) return;
-    k5_json_release(token->header);
-    k5_json_release(token->body);
-    free(token);
+    if (! local_token) return;
+    if (local_token->data) free(local_token->data);
+    if (local_token->head) free(local_token->head);
+    if (local_token->payload) free(local_token->payload);
+    if (local_token->signature) free(local_token->signature);
+    if (local_token->head_d) free(local_token->head_d);
+    if (local_token->payload_d) free(local_token->payload_d);
+    free(local_token);
 }
 
 static
@@ -169,85 +192,8 @@ base64url_decode(const char *str, size_t *len_out)
 }
 
 int
-jwt_token_decode(char *token, jwt_token **out)
+jwt_token_extract_int(const char *token, const char *sPattern) 
 {
-    char *p, *part1, *part2, *header, *header_t, *body, *body_t, *principal;
-    k5_json_value jvalue;
-    jwt_token *token_out;
-    size_t len_out = 0;
-    int retval = 0;
-    int x = 0;
-
-    *out = NULL;
-    p = strchr(token, '.');
-    if (p == NULL) {
-        return 1;
-    }
-    *p++ = 0;
-    if (p == NULL) {
-        return 1;
-    }    
-    part1 = token;
-    part2 = p;
-    p = strchr(part2, '.');
-    if (p != NULL) {
-        *p++ = 0;
-    }
-    
-    header = (char*)base64url_decode((const char*)part1, &len_out);
-    header_t = (char *)malloc(len_out);
-    strncpy(header_t, header, len_out);
-    header_t[len_out] = '\0';
-    free(header);
-    body = (char*)base64url_decode((const char*)part2, &len_out);
-    body_t = (char *)malloc(len_out);
-    strncpy(body_t, body, len_out);
-    body_t[len_out] = '\0';
-    free(body);
-   
-    token_out = (jwt_token*)calloc(1, sizeof(*token_out));
-    k5_json_decode(header_t, &token_out->header);
-    k5_json_decode(body_t, &token_out->body);
-
-    free(header_t);
-    free(body_t);
-
-    principal = jwt_token_header_attr(token_out, "krbPrincipal");
-    if (principal == NULL) {
-    	principal = jwt_token_header_attr(token_out, "user_name");
-    	if (principal == NULL) {
-    	    principal = jwt_token_header_attr(token_out, "username");
-    	}
-    }
-    if (principal == NULL) {
-        principal = jwt_token_body_attr(token_out, "krbPrincipal");
-        if (principal == NULL) {
-    	    principal = jwt_token_body_attr(token_out, "user_name");
-    	    if (principal == NULL) {
-    	        principal = jwt_token_body_attr(token_out, "username");
-    	    }
-        }
-    }
-    if (principal == NULL) {
-        printf("Invalid token, unknown kr5 principal or user name\n");
-        return 1;
-    }
-
-    // replace @ to _
-    for(x=0; x<strlen(principal); x++) {
-      if(principal[x]=='@')
-        principal[x] = '_';
-    }
-
-    printf("krbPrincipal: %s\n", principal);
-
-    jwt_token_destroy(token_out);   
-
-    return 0;
-}
-
-int
-jwt_extract_int(const char *token, const char *sPattern) {
   const char * principal = token, * cPattern = sPattern;
   int x = -3;
   for(;*principal != 0;principal++) {
@@ -288,6 +234,156 @@ jwt_extract_int(const char *token, const char *sPattern) {
   return x;
 }
 
+
+int
+jwt_token_structure_check(jwt_token * token)
+{
+    char * part1, * part2, * part3, * p, * local_token;
+    
+    if (token == NULL || token->data == NULL) {
+      return 1;
+    }
+    
+    local_token = (char *)malloc(strlen(token->data) + 1);
+    strncpy(local_token, token->data, strlen(token->data));
+    local_token[strlen(token->data)] = 0;
+    
+    part1 = local_token;
+    
+    p = strchr(local_token, '.');
+    if (p == NULL) {
+        return 1;
+    }
+    *p++ = 0;
+    
+    part2 = p;
+    p = strchr(p, '.');
+    if (p == NULL) {
+        return 1;
+    }
+    *p++ = 0;
+    
+    if (*p == 0) {
+      return 1;
+    }
+    part3 = p;
+    
+    token->head = (char *)malloc(strlen(part1) + 1);
+    strncpy(token->head, part1, strlen(part1) + 1);
+    
+    token->payload = (char *)malloc(strlen(part2) + 1);
+    strncpy(token->payload, part2, strlen(part2) + 1);
+    
+    token->signature = (char *)malloc(strlen(part3) + 1);
+    strncpy(token->signature, part3, strlen(part3) + 1);
+    
+    free(local_token);
+    return 0;
+}
+
+int
+jwt_token_decode(jwt_token * token) 
+{
+  size_t len_out = 0;
+  char * part1, * part2, * part1_d, * part2_d;
+  
+  if (token == NULL || token->head == NULL || token->payload == NULL) {
+    return 1;
+  }
+  
+  part1 = (char *)base64url_decode(token->head, &len_out);
+  if (part1 == NULL) {
+    return 1;
+  }
+  
+  part2 = (char *)base64url_decode(token->payload, &len_out);
+  if (part2 == NULL) {
+    return 1;
+  }
+  
+  token->head_d = part1;
+  token->payload_d = part2;
+  
+  return 0;
+}
+
+char * jwt_token_get_name(jwt_token * token) 
+{
+  char * principal;
+  int x;
+  
+  if (token == NULL || token->head_d == NULL || token->payload_d == NULL) {
+    return NULL;
+  }
+  
+  principal = jwt_token_header_attr(token, "krbPrincipal");
+  if (principal == NULL) {
+    principal = jwt_token_header_attr(token, "user_name");
+    if (principal == NULL) {
+      principal = jwt_token_header_attr(token, "username");
+    }
+  }
+  
+  if (principal == NULL) {
+    principal = jwt_token_body_attr(token, "krbPrincipal");
+    if (principal == NULL) {
+      principal = jwt_token_body_attr(token, "user_name");
+      if (principal == NULL) {
+        principal = jwt_token_body_attr(token, "username");
+      }
+    }
+  }
+  
+  if (principal == NULL) {
+    return NULL;
+  }
+  
+  // Replace @ to _ in principal name from token
+  for(x=0; x<strlen(principal); x++) {
+    if(principal[x]=='@')
+      principal[x] = '_';
+  }
+  
+  return principal;
+}
+
+int jwt_token_validate_principal_name(jwt_token * token, const char * user_name) 
+{
+  char * principal;
+  int x;
+  
+  principal = jwt_token_get_name(token);
+  
+  if (principal == NULL) {
+    return 2;
+  }
+  
+  if(strlen(principal) != strlen(user_name))
+    return 1;
+  else{
+    for(x=0;x<strlen(principal);x++){
+      if(principal[x]!=user_name[x]){
+        return 1;
+      }
+    }
+  }
+  
+  return 0;
+}
+
+int jwt_token_lifetime(jwt_token * token, krb5_timestamp * endtime) 
+{
+  int x = jwt_token_extract_int(token->payload_d, "\"exp\"");
+  
+  if(x<=(int)time(NULL)) {
+    return 1;
+  }
+  
+  *endtime = x;
+  
+  return 0;
+}
+
 void sha256(char *string, char outputBuffer[32])
 {
     unsigned char hash[SHA256_DIGEST_LENGTH];
@@ -299,125 +395,39 @@ void sha256(char *string, char outputBuffer[32])
     strncpy(outputBuffer, hash, 32);
 }
 
-int
-jwt_token_decode_and_check(char *token, const char *user_name, krb5_timestamp *endtime, void * rsa_public)
+int jwt_token_verify_signature(jwt_token * token, const RSA * rsa_public) 
 {
-    char *p, *part1, *part2, *part3, *header, *header_t, *body, *body_t, *signature, *principal;
-    k5_json_value jvalue;
-    jwt_token *token_out;
-    size_t len_out = 0;
-    int retval = 0;
-    int x = 0;
-    RSA * rsa = (RSA *)rsa_public;
-
-    p = strchr(token, '.');
-    if (p == NULL) {
-        return 1;
-    }
-    *p++ = 0;
-    if (p == NULL) {
-        return 1;
-    }
-    part1 = token;
-    part2 = p;
-    p = strchr(part2, '.');
-    if (p != NULL) {
-        *p++ = 0;
-    }
-    part3 = p;
-
-    header = (char*)base64url_decode((const char*)part1, &len_out);
-    header_t = (char *)malloc(len_out);
-    strncpy(header_t, header, len_out);
-    header_t[len_out] = '\0';
-    free(header);
-    body = (char*)base64url_decode((const char*)part2, &len_out);
-    body_t = (char *)malloc(len_out);
-    strncpy(body_t, body, len_out);
-    body_t[len_out] = '\0';
-    free(body);
-
-    token_out = (jwt_token*)calloc(1, sizeof(*token_out));
-    k5_json_decode(header_t, &token_out->header);
-    k5_json_decode(body_t, &token_out->body);
-
-    free(header_t);
-
-    principal = jwt_token_header_attr(token_out, "krbPrincipal");
-    if (principal == NULL) {
-        principal = jwt_token_header_attr(token_out, "user_name");
-        if (principal == NULL) {
-            principal = jwt_token_header_attr(token_out, "username");
-        }
-    }
-    if (principal == NULL) {
-        principal = jwt_token_body_attr(token_out, "krbPrincipal");
-        if (principal == NULL) {
-            principal = jwt_token_body_attr(token_out, "user_name");
-            if (principal == NULL) {
-                principal = jwt_token_body_attr(token_out, "username");
-            }
-        }
-    }
-    if (principal == NULL) {
-        printf("Invalid token, unknown kr5 principal or user name\n");
-        retval = 1;
-        com_err("jwt_err", 0, "Cannot find principal username");
-        goto clean;
-    }
-    
-    // replace @ to _
-    for(x=0; x<strlen(principal); x++) {
-      if(principal[x]=='@')
-        principal[x] = '_';
-    }
-
-    if(strlen(principal) != strlen(user_name))
-      retval = 1;
-    else{
-      for(x=0;x<strlen(principal);x++){
-        if(principal[x]!=user_name[x]){
-          retval = 1;
-          com_err("jwt_compare", 0, "Compare names failed");
-          goto clean;
-        }
-      }
-    }
-
-    x = jwt_extract_int(body_t, "\"exp\"");
-
-    if(x<=(int)time(NULL)) {
-      retval = 1;
-      com_err("jwt_exp", 0, "Token expired");
-      goto clean;
-    }    
-    
-    *endtime = x;
-
-    //Format part1 and part2
-    part1[strlen(part1)] = '.';
-    signature = (char*)base64url_decode((const char*)part3, &len_out);
+  char * part1, * signature_d;
+  int ret;
+  size_t len_out;
+  char * head = (char *)malloc(strlen(token->head) + strlen(token->payload) + 2);
   
-    // If token is longer than sha256 hash result (32 bits) we have to hash it to expected lenght
-    if(strlen(part1)>32) {
-      part2 = malloc(32);
-      sha256(part1, part2);
-      x = RSA_verify(NID_sha256, part2, 32, signature, len_out, rsa);
-      free(part2);
-    } 
-    else
-      x = RSA_verify(NID_sha256, (unsigned char *)part1, strlen(part1), signature, len_out, rsa);
-
-    // 0 - failed, 1 - success
-    if(x != 1) {
-      retval = 1;
-      com_err("jwt_rsa", 0, "RSA PubKey validation failed");
-      goto clean;
-    }
-clean:
-    free(body_t);
-    jwt_token_destroy(token_out);
-
-    return retval;
+  strncpy(head, token->head, strlen(token->head));
+  head[strlen(token->head)] = '.';
+  
+  strncpy(head + 1 + strlen(token->head), token->payload, strlen(token->payload));
+  head[strlen(token->head) + strlen(token->payload) + 1] = 0;
+  
+  part1 = (char *)base64url_decode(token->signature, &len_out);
+  if (part1 == NULL) {
+    return 1;
+  }
+  signature_d = (char *)malloc(len_out + 1);
+  strncpy(signature_d, part1, len_out);
+  free(part1);
+  
+  if(strlen(head)>32) {
+    part1 = malloc(32);
+    sha256(head, part1);
+    ret = RSA_verify(NID_sha256, part1, 32, signature_d, len_out, rsa_public);
+    free(part1);
+  } 
+  else
+    ret = RSA_verify(NID_sha256, (unsigned char *)head, strlen(head), signature_d, len_out, rsa_public);
+  
+  free(head);
+  if (ret == 0) {
+    return 1;
+  }
+  return 0;
 }
-


### PR DESCRIPTION
Kerberos with jwt support.

Changes:
-   added code for cleanup/free memory etc., fixing resources leaks. The PoC is now stable. 
-   added JWT token validation logic
-   added lazy Kerberos accounts creation, so there is no need to create accounts in OAuth and Kerberos.
-   Added OAuth and Kerberos token lifetime synchronization. There is a logic that can do that, but it is not used currently due to very short OAuth tokens lifetimes.

P.S.
I can squash commits if you want.
